### PR TITLE
Syncing dev with v1.4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ workflows:
   release:
     jobs:
       - go/build:
+          context: go_public
           github-config-private-package: false
           dry-run-release: false
           filters:

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "__comment": "This is dummy file to respect the current versioning tool",
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "__comment": "This is dummy file to respect the current versioning tool",
-  "version": "1.4.2"
+  "version": "1.5.0"
 }


### PR DESCRIPTION
Fixes made in v1.4.2 should appear in the dev branch

-- 
[habx](https://www.habx.com/tech/)'s create_release v0.34.0
