### PR TITLE
Revert "Update docker orb to v2.1.1"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ alias:
 # --------------------------------------------------- #
 orbs:
   go: habx/golang@0.9.1
-  docker: circleci/docker@2.1.1
+  docker: circleci/docker@2.0.4
 
 docker-config: &docker-config
   extra_build_args: '--build-arg REVISION="$(git rev-parse --short HEAD)" --build-arg CREATED="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --build-arg VERSION="$CIRCLE_TAG" --build-arg TITLE="${CIRCLE_PROJECT_REPONAME}" --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" --build-arg AUTHORS="${CIRCLE_USERNAME}"'


### PR DESCRIPTION
Reverts habx/aws-mq-cleaner#388

https://github.com/CircleCI-Public/docker-orb/issues/125